### PR TITLE
add args.verbose == 0 case

### DIFF
--- a/ead-html-validator.py
+++ b/ead-html-validator.py
@@ -432,7 +432,9 @@ def main():
 
     util.addLoggingLevel("TRACE", logging.DEBUG - 5)
 
-    if args.verbose == 1:
+    if args.verbose == 0:
+        pass # noop
+    elif args.verbose == 1:
         logging.getLogger().setLevel(logging.INFO)
     elif args.verbose == 2:
         logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
Add case for default verbose == 0 case to suppress error message when running with the default verbosity.

Without this change, the script would always output the verbosity assertion message before the validation results:
```
$ ./ead-html-validator.py ../../nyudlts/findingaids_eads_test/tamwag/mos_2021.xml ../../nyudlts/findingaids-hugo-public/tamwag/mos_2021/
You can only specify -v a maximum of 3 times.
usage: ead-html-validator.py [-h] [--diff-type {color,unified,unified-color,simple}] [--verbose] [--log-format LOG_FORMAT] [--tidy] [--indent] [--broken-links] [--color] EAD_FILE HTML_DIR

Validate finding aids html against ead xml file.

positional arguments:
  EAD_FILE              ead file
  HTML_DIR              html directory

optional arguments:
  -h, --help            show this help message and exit
  --diff-type {color,unified,unified-color,simple}
                        diff type (default: simple)
  --verbose, -v         Verbose mode. Multiple -v options increase the verbosity. The maximum is 3. (default: 0)
  --log-format LOG_FORMAT, -l LOG_FORMAT
                        format for logging messages (default: %(asctime)s - ead-html-validator - %(levelname)s - %(message)s)
  --tidy, -t            Run HTML Tidy to test correctness of html (default: False)
  --indent, -i          Indent HTML files using tidy. (default: False)
  --broken-links, -b    Find broken urls (default: False)
  --color, -c           Enable color output (default: False)
ERROR: field 'dao' differs for c id='aspace_499449c48c751a22b7c222d3ce2c2879'
DIFF:
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[{'dao 1.': {'desc': ['This is a digital object'], 'link': ['https://hdl.handle.net/2333.1/7h44j74d'], 'role': ['audio-service']}}, {'dao 2.': {'desc': ['Archived website of Julie Kathryn'], 'link': ['https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com', 'https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com'], 'role': ['external-link']}}]
!=
[{'dao 1.': {'desc': ['This is a digital object'], 'link': ['/tamwag/mos_2021/audio/7h44j74d/'], 'role': ['audio-service']}}, {'dao 2.': {'desc': ['Archived website of Julie Kathryn'], 'link': ['https://wayback.archive-it.org/9900/*/http://www.iamsnowangel.com', 'https://wayback.archive-it.org/4049/*/http://www.iamsnowangel.com'], 'role': ['external-link']}}]
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
...
```