### PR TITLE
suggest some README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,39 +29,39 @@ following modules:
 
 Ensure that you have Python 3.9+ installed on your system:
 ```
-    python3.9 -V
+python3.9 -V
 ```
 
 To install Python 3.9 on a Linux system:
 ```
-    sudo su -
-    dnf install python39 -y
+sudo su -
+dnf install python39 -y
 ```
 
 Checkout validator repository on github:
 ```
-    cd ~
-    git clone https://github.com/rrasch/ead-html-validator.git
+cd ~
+git clone https://github.com/rrasch/ead-html-validator.git
 ```
 
 Set up virtual environment:
 ```
-    mkdir ~/venv
-    cd ~/venv
-    python3.9 -m venv ead-html-validator
-    source ead-html-validator/bin/activate
-    pip3 install -r ~/ead-html-validator/requirements.txt
+mkdir ~/venv
+cd ~/venv
+python3.9 -m venv ead-html-validator
+source ead-html-validator/bin/activate
+pip3 install -r ~/ead-html-validator/requirements.txt
 ```
 
 Test out the script:
 ```
-    cd ~/ead-html-validator
-    ./ead-html-validator.py
+cd ~/ead-html-validator
+./ead-html-validator.py
 ```
 
 To exit the virtual enviroment:
 ```
-    deactivate
+deactivate
 ```
 
 ## Usage ##

--- a/README.md
+++ b/README.md
@@ -27,27 +27,42 @@ following modules:
 
 ## Installation
 
-Checkout validator repository on github:
+Ensure that you have Python 3.9+ installed on your system:
+```
+    python3.9 -V
+```
 
-    $ cd ~
-    $ git clone https://github.com/rrasch/ead-html-validator.git
+To install Python 3.9 on a Linux system:
+```
+    sudo su -
+    dnf install python39 -y
+```
+
+Checkout validator repository on github:
+```
+    cd ~
+    git clone https://github.com/rrasch/ead-html-validator.git
+```
 
 Set up virtual environment:
-
-    $ mkdir ~/venv
-    $ cd ~/venv
-    $ python3 -m venv ead-html-validator
-    $ source ead-html-validator/bin/activate
-    $ pip3 install -r ~/ead-html-validator/requirements.txt
+```
+    mkdir ~/venv
+    cd ~/venv
+    python3.9 -m venv ead-html-validator
+    source ead-html-validator/bin/activate
+    pip3 install -r ~/ead-html-validator/requirements.txt
+```
 
 Test out the script:
-
-    $ cd ~/ead-html-validator
-    $ ./ead-html-validator.py
+```
+    cd ~/ead-html-validator
+    ./ead-html-validator.py
+```
 
 To exit the virtual enviroment:
-
-    $ deactivate
+```
+    deactivate
+```
 
 ## Usage ##
 
@@ -57,8 +72,9 @@ The tools takes in two arguments:
 - the path to a directory containing HTML files
 
 The command line looks like the following
-
+```
     ead-html-validator <ead_xml_file> <finding_aids_html_dir>
+```
 
 ## Debugging
 


### PR DESCRIPTION
Hi @rrasch ,

I tried to install the validator on a dev worker host following instructions in the README, and remembered that there were some extra steps that I needed to follow to get the validator running on the RCDC hosts, e.g., installing `Python 3.9`.

I added those steps to the README file so I won't forget in the future.

I also wrapped the installation commands in triple backquotes and removed the `$` so that folks can use GitHub's copy feature to just copy the set of commands and run them, e.g., 
![image](https://github.com/rrasch/ead-html-validator/assets/79021/7e4c1246-2e86-40c7-9617-0d52ab3ae41d)

Feel free to ignore this PR if you don't agree with these tweaks.

Thanks again for developing this tool!
Best-
Joe